### PR TITLE
Don't pull all the PyObjC frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This module also provides a [selector](https://docs.python.org/3/library/selecto
 $ pip3 install corefoundationasyncio
 ```
 
-This module depends on [pyobjc](https://pypi.org/project/pyobjc/)
+This module depends on [pyobjc-framework-Cocoa](https://pypi.org/project/pyobjc-framework-Cocoa/)
 
 ## Contributing
 

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,6 @@ setup(
         'Operating System :: MacOS :: MacOS X',
         'Programming Language :: Python',
     ],
-    install_requires=['pyobjc'],
+    install_requires=['pyobjc-framework-Cocoa'],
     py_modules = ['corefoundationasyncio', 'corefoundationselector'],
 )


### PR DESCRIPTION
Hey, thanks for the work here!

Currently trying `corefoundationasyncio` and noticed that it pulls all frameworks, which is quite long. I guess it just needs `pyobjc-framework-Cocoa`, right? :)